### PR TITLE
Migrate from javax to jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,12 @@
     </developers>
 
     <properties>
-        <postmark.version>1.8.0</postmark.version>
+        <postmark.version>1.8.0-jakarta-SNAPSHOT</postmark.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <jackson.minimum.version>2.9.7</jackson.minimum.version>
-        <jackson.version>2.10.0</jackson.version>
-        <jersey.version>2.35</jersey.version>
+        <jackson.version>2.13.2</jackson.version>
+        <jersey.version>3.0.4</jersey.version>
         <junit.jupiter.version>5.8.2</junit.jupiter.version>
         <junit.platform.version>1.3.2</junit.platform.version>
     </properties>
@@ -64,9 +64,9 @@
 
         <!-- Jersey client requires this dependency -->
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-            <version>1.1.1</version>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+            <version>2.0.1</version>
         </dependency>
 
         <!-- Serialization to JSON -->

--- a/src/main/java/com/wildbit/java/postmark/Postmark.java
+++ b/src/main/java/com/wildbit/java/postmark/Postmark.java
@@ -3,8 +3,8 @@ package com.wildbit.java.postmark;
 import com.wildbit.java.postmark.client.AccountApiClient;
 import com.wildbit.java.postmark.client.ApiClient;
 
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 import java.io.InputStream;
 import java.util.Properties;
 import java.util.logging.Logger;

--- a/src/main/java/com/wildbit/java/postmark/client/AccountApiClient.java
+++ b/src/main/java/com/wildbit/java/postmark/client/AccountApiClient.java
@@ -1,16 +1,19 @@
 package com.wildbit.java.postmark.client;
 
 import com.wildbit.java.postmark.client.data.model.RequestResponse;
-import com.wildbit.java.postmark.client.data.model.domains.*;
-import com.wildbit.java.postmark.client.data.model.senders.*;
+import com.wildbit.java.postmark.client.data.model.domains.Domain;
+import com.wildbit.java.postmark.client.data.model.domains.DomainDetails;
+import com.wildbit.java.postmark.client.data.model.domains.Domains;
+import com.wildbit.java.postmark.client.data.model.senders.SignatureDetails;
+import com.wildbit.java.postmark.client.data.model.senders.SignatureToCreate;
+import com.wildbit.java.postmark.client.data.model.senders.Signatures;
 import com.wildbit.java.postmark.client.data.model.server.Server;
 import com.wildbit.java.postmark.client.data.model.servers.Servers;
 import com.wildbit.java.postmark.client.data.model.templates.TemplatesPush;
-import com.wildbit.java.postmark.client.data.model.templates.TemplatesPushAction;
 import com.wildbit.java.postmark.client.data.model.templates.TemplatesPushRequest;
 import com.wildbit.java.postmark.client.exception.PostmarkException;
+import jakarta.ws.rs.core.MultivaluedMap;
 
-import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 
 /**

--- a/src/main/java/com/wildbit/java/postmark/client/ApiClient.java
+++ b/src/main/java/com/wildbit/java/postmark/client/ApiClient.java
@@ -24,7 +24,7 @@ import com.wildbit.java.postmark.client.data.model.webhooks.Webhook;
 import com.wildbit.java.postmark.client.data.model.webhooks.Webhooks;
 import com.wildbit.java.postmark.client.exception.PostmarkException;
 
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/main/java/com/wildbit/java/postmark/client/BaseApiClient.java
+++ b/src/main/java/com/wildbit/java/postmark/client/BaseApiClient.java
@@ -1,6 +1,6 @@
 package com.wildbit.java.postmark.client;
 
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 /**
  * Class that handles (on very high level) API requests. All Postmark public endpoints which

--- a/src/main/java/com/wildbit/java/postmark/client/HttpClient.java
+++ b/src/main/java/com/wildbit/java/postmark/client/HttpClient.java
@@ -3,12 +3,12 @@ package com.wildbit.java.postmark.client;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 
 /**
  * Base HTTP client class solely responsible for making

--- a/src/main/java/com/wildbit/java/postmark/client/HttpClientHandler.java
+++ b/src/main/java/com/wildbit/java/postmark/client/HttpClientHandler.java
@@ -3,7 +3,7 @@ package com.wildbit.java.postmark.client;
 import com.wildbit.java.postmark.client.data.DataHandler;
 import com.wildbit.java.postmark.client.exception.*;
 
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 
 /**

--- a/src/test/java/base/BaseTest.java
+++ b/src/test/java/base/BaseTest.java
@@ -6,10 +6,11 @@ import com.wildbit.java.postmark.client.ApiClient;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Properties;
-
-import java.nio.file.*;
 
 /**
  * Created by bash on 11/14/17.

--- a/src/test/java/unit/client/ApiClientTest.java
+++ b/src/test/java/unit/client/ApiClientTest.java
@@ -2,7 +2,7 @@ package unit.client;
 
 import com.wildbit.java.postmark.Postmark;
 import com.wildbit.java.postmark.client.ApiClient;
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/src/test/java/unit/client/BaseApiClientTest.java
+++ b/src/test/java/unit/client/BaseApiClientTest.java
@@ -5,7 +5,7 @@ import com.wildbit.java.postmark.client.BaseApiClient;
 import com.wildbit.java.postmark.client.HttpClient;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**

--- a/src/test/java/unit/client/HttpClientTest.java
+++ b/src/test/java/unit/client/HttpClientTest.java
@@ -5,7 +5,7 @@ import com.wildbit.java.postmark.client.HttpClient;
 import com.wildbit.java.postmark.client.exception.PostmarkException;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedHashMap;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
People are more and more migrating to the newer EE versions (Jakarta). Jetty 11 has been out for more than a year and depends on jakarta. Spring 6 (release data: Q4 2022) will depend on jakarta. https://spring.io/blog/2021/09/02/a-java-17-and-jakarta-ee-9-baseline-for-spring-framework-6

I suggest you introduce two versions of postmark-java: One depending on javax and one on jakarta, maybe on two different branches.