### PR TITLE
Update default timeout to be consistent with other libraries

### DIFF
--- a/src/main/java/com/postmarkapp/postmark/client/HttpClient.java
+++ b/src/main/java/com/postmarkapp/postmark/client/HttpClient.java
@@ -18,8 +18,8 @@ public class HttpClient {
 
     // HTTP request connection timeouts
     public enum DEFAULTS {
-        CONNECT_TIMEOUT_SECONDS(5),
-        READ_TIMEOUT_SECONDS(15);
+        CONNECT_TIMEOUT_SECONDS(60),
+        READ_TIMEOUT_SECONDS(60);
 
         public final int value;
 


### PR DESCRIPTION
## What

Updates timeout to 60s to be consistent with ActiveCampaign/postmark-gem#133, https://github.com/ActiveCampaign/postmark-php/pull/100, https://github.com/ActiveCampaign/postmark-dotnet/pull/114 and others.