### PR TITLE
add second artifact with support for Jakarta EE through eclipse transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Add the dependency to your project:
 </dependency>
 ```
 
+If you need a version compatible with Jakarta EE, you can get it with the jakarta classifier:
+
+``` xml
+<dependency>
+    <groupId>com.postmarkapp</groupId>
+    <artifactId>postmark</artifactId>
+    <version>{version}</version>
+    <classifier>jakarta</classifier>
+</dependency>
+```
+
 Note: to retrieve the latest version number, visit [maven central repository](https://repo1.maven.org/maven2/com/postmarkapp/postmark/) , or check the badge at top of the page which is showing the latest version synced to Maven repository.
 [Maven central repository link](https://repo1.maven.org/maven2/com/postmarkapp/postmark/) might be slightly more accurate, in case when new version was published recently.
 

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,24 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.eclipse.transformer</groupId>
+                <artifactId>transformer-maven-plugin</artifactId>
+                <version>0.5.0</version>
+                <executions>
+                    <execution>
+                        <id>jakarta-ee</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <classifier>jakarta</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
 
         <!-- Resources path -->


### PR DESCRIPTION
There are already discussion about migrating from javax to jakarta (#47 & #35). 

This would however create a second artifact with support for Jakarta which could be included by the user of the library as needed while still maintaining backward compatibility for now.