### PR TITLE
fix encoding for request body

### DIFF
--- a/src/main/java/com/postmarkapp/postmark/client/HttpClient.java
+++ b/src/main/java/com/postmarkapp/postmark/client/HttpClient.java
@@ -4,11 +4,14 @@ import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.apache.hc.core5.util.Timeout;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -77,15 +80,15 @@ public class HttpClient {
 
         switch (requestType) {
             case POST:
-                request = ClassicRequestBuilder.post(getHttpUrl(url)).setEntity(data).build();
+                request = ClassicRequestBuilder.post(getHttpUrl(url)).setEntity(data, ContentType.APPLICATION_JSON).build();
                 break;
 
             case PUT:
-                request = ClassicRequestBuilder.put(getHttpUrl(url)).setEntity(data).build();
+                request = ClassicRequestBuilder.put(getHttpUrl(url)).setEntity(data, ContentType.APPLICATION_JSON).build();
                 break;
 
             case PATCH:
-                request = ClassicRequestBuilder.patch(getHttpUrl(url)).setEntity(data).build();
+                request = ClassicRequestBuilder.patch(getHttpUrl(url)).setEntity(data, ContentType.APPLICATION_JSON).build();
                 break;
 
             case DELETE:

--- a/src/test/java/integration/TemplateTest.java
+++ b/src/test/java/integration/TemplateTest.java
@@ -72,6 +72,29 @@ public class TemplateTest extends BaseTest {
     }
 
     @Test
+    void createTemplate_should_work_with_utf_8() throws PostmarkException, IOException {
+
+        String utf8String = "test html with unicode symbols: € Ä Æ ©";
+        String templateName = "name";
+
+        TemplateContent templateContent = new TemplateContent();
+        templateContent.setHtmlBody(utf8String);
+        templateContent.setTextBody("test text");
+        templateContent.setName(templateName);
+        templateContent.setSubject("subject");
+
+        BaseTemplate response = client.createTemplate(templateContent);
+        assertEquals(response.getName(),templateName);
+
+        Template template = client.getTemplate(response.getTemplateId());
+        assertEquals(utf8String, template.getHtmlBody());
+
+        Integer id = response.getTemplateId();
+        client.deleteTemplate(id);
+
+    }
+
+    @Test
     void deleteTemplate() throws PostmarkException, IOException {
         String templateName = "deleteName";
 


### PR DESCRIPTION
First of all, thank you very much for fixing #35 by moving to the Apache HTTP client!

While testing the new version, I noticed that special characters were not encoded correctly when sending an email.

Using setEntity without a ContentType defaults to text/plain with ISO 8859-1, explicitly setting it to application/json solves the encoding issue.