### PR TITLE
Prevent API parse error when names contain quotes

### DIFF
--- a/src/main/java/com/postmarkapp/postmark/client/data/model/message/BaseMessage.java
+++ b/src/main/java/com/postmarkapp/postmark/client/data/model/message/BaseMessage.java
@@ -367,6 +367,10 @@ public class BaseMessage {
 
     private String convertRecipient(String name, String address) {
         StringBuilder recipientsString = new StringBuilder();
+        if (name != null) {
+            // Escape characters that otherwise cause parsing errors in the API
+            name = name.replace("\"", "\\\"");
+        }
         return recipientsString.append("\"").append(name).append("\"")
                 .append("<").append(address).append(">").toString();
     }

--- a/src/test/java/unit/data/MessageTest.java
+++ b/src/test/java/unit/data/MessageTest.java
@@ -184,6 +184,28 @@ public class MessageTest extends BaseTest {
     }
 
     @Test
+    void recipientsWithQuotesAreEscapedProperly() {
+        Message message = new Message();
+        String nameWithQuote = "John \"Smith\"";
+        String email = "john@example.com";
+
+        Map<String, String> recipients = new HashMap<>();
+        recipients.put(nameWithQuote, email);
+
+        message.setTo(recipients);
+        assertEquals("\"John \\\"Smith\\\"\"<john@example.com>", message.getTo());
+
+        message.setCc(recipients);
+        assertEquals("\"John \\\"Smith\\\"\"<john@example.com>", message.getCc());
+
+        message.setBcc(recipients);
+        assertEquals("\"John \\\"Smith\\\"\"<john@example.com>", message.getBcc());
+
+        message.setFrom(nameWithQuote, email);
+        assertEquals("\"John \\\"Smith\\\"\"<john@example.com>", message.getFrom());
+    }
+
+    @Test
     void attachmentException() throws IOException {
         Message message = new Message();
         assertThrows(java.nio.file.NoSuchFileException.class, () -> message.addAttachment("test"));


### PR DESCRIPTION
This way, it's possible to call `message.setTo(Map.of(name, address))` without first having to escape the `name`.

This should fix #65.

Note:
- If there are other characters that might also need escaping, I can add those as well. Also, if there's another way of escaping than this simple `.replace` call, I can change it.
- I didn't add an integration test, but let me know if that's desired.
- I saw in the other tests inside MessageTest that `assertEquals` are reversed: expected <-> actual. I didn't modify them to keep this PR focused, but just so you know.