### PR TITLE
PMK-1955: Java Update Vulnerable Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <jackson.minimum.version>2.9.7</jackson.minimum.version>
-        <jackson.version>2.14.1</jackson.version>
+        <jackson.version>2.18.2</jackson.version>
         <junit.jupiter.version>5.8.2</junit.jupiter.version>
         <junit.platform.version>1.3.2</junit.platform.version>
     </properties>
@@ -77,7 +77,14 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>2.7.0</version>
+            <version>2.9.2</version>
+        </dependency>
+
+        <!-- Override transitive commons-io to fix CVE (Resource Exhaustion) -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.17.0</version>
         </dependency>
 
 


### PR DESCRIPTION
Jira ticket:
-[PMK-1955](https://activecampaign.atlassian.net/browse/PMK-1955)

What?
After running [Snyk on this repo main branch](https://app.snyk.io/org/campy/project/e7b50402-ff51-4305-ab62-16674f91bc73), it could find 5 dependency vulnerabilities.

<img width="1728" height="1117" alt="Screenshot 2025-12-26 at 12 56 18 PM" src="https://github.com/user-attachments/assets/c5f9600b-3dd0-4f69-b4ef-88b08f1f8f01" />

<img width="1728" height="1117" alt="Screenshot 2025-12-26 at 12 55 30 PM" src="https://github.com/user-attachments/assets/527ae77c-23a6-4062-9d33-7ffb03cd2a87" />


<img width="1728" height="1117" alt="Screenshot 2025-12-26 at 12 55 41 PM" src="https://github.com/user-attachments/assets/0801eee0-4a03-4f28-8c57-e1fa4cdcd30d" />

How?
The tool Snyk suggest to upgrade the versions of the dependencies. That fix was done in the pom.xml file.

[PMK-1955]: https://activecampaign.atlassian.net/browse/PMK-1955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ